### PR TITLE
feat(toolkit): adapt to Ash CLI archiving

### DIFF
--- a/docs/toolkit/ansible-avalanche-collection/changelog.md
+++ b/docs/toolkit/ansible-avalanche-collection/changelog.md
@@ -1,8 +1,17 @@
 # Changelog
 
-## [Unreleased](https://github.com/AshAvalanche/ansible-avalanche-collection/tree/HEAD)
+## [v0.8.1](https://github.com/AshAvalanche/ansible-avalanche-collection/tree/v0.8.1) (2023-06-14)
 
-[Full Changelog](https://github.com/AshAvalanche/ansible-avalanche-collection/compare/v0.7.6...HEAD)
+[Full Changelog](https://github.com/AshAvalanche/ansible-avalanche-collection/compare/v0.8.0...v0.8.1)
+
+**Merged pull requests:**
+
+- feat\(ash\_cli\): unpack Ash CLI archive [\#71](https://github.com/AshAvalanche/ansible-avalanche-collection/pull/71) ([Nuttymoon](https://github.com/Nuttymoon))
+- feat: sync dashboards with avalanche-monitoring [\#70](https://github.com/AshAvalanche/ansible-avalanche-collection/pull/70) ([leopaul36](https://github.com/leopaul36))
+
+## [v0.8.0](https://github.com/AshAvalanche/ansible-avalanche-collection/tree/v0.8.0) (2023-06-09)
+
+[Full Changelog](https://github.com/AshAvalanche/ansible-avalanche-collection/compare/v0.7.6...v0.8.0)
 
 **Breaking changes:**
 

--- a/docs/toolkit/ash-cli/installation.md
+++ b/docs/toolkit/ash-cli/installation.md
@@ -30,21 +30,22 @@ ash help
 
 ## Fastest method: binary release download
 
-:::caution
-The binary release is only available for Linux at the moment.
-:::
-
 The binary releases are available on the [GitHub releases page](https://github.com/AshAvalanche/ash-rs/releases).
 
-Download the latest release (e.g. `v0.1.1`) and make it executable:
+Download the latest release (e.g. `v0.2.1`) and make it executable:
 
 ```bash
-# Download the binary release
-wget https://github.com/AshAvalanche/ash-rs/releases/download/v0.1.1/ash-linux-amd64-v0.1.1 -O ash
-# Download the binary checksum
-wget https://github.com/AshAvalanche/ash-rs/releases/download/v0.1.1/ash-linux-amd64-v0.1.1.sha512 -O ash.sha512
-# Verify the checksum
-sha512sum -c ash.sha512
+export ASH_VERSION=v0.2.1
+# Can be 'linux' or 'macos'
+export OS=linux
+# Can be 'amd64' or 'arm64'
+export ARCH=amd64
+# Download the binary archive
+curl -sSfL "https://github.com/AshAvalanche/ash-rs/releases/download/${ASH_VERSION}/ash-${OS}-${ARCH}-${ASH_VERSION}.tar.gz" -o "ash-${OS}-${ARCH}-${ASH_VERSION}.tar.gz"
+# Verify binary checksum
+curl -sSfL "https://github.com/AshAvalanche/ash-rs/releases/download/${ASH_VERSION}/ash-${OS}-${ARCH}-${ASH_VERSION}.tar.gz.sha512" | sha512sum -c
+# Extract the binary
+tar -xzf ash-linux-amd64-${ASH_VERSION}.tar.gz
 # Make the binary executable
 chmod +x ash
 ```
@@ -54,3 +55,7 @@ You are now ready to use the Ash CLI!
 ```bash
 ./ash help
 ```
+
+:::tip
+On MacOS, you will probably need to allow the binary to run in your security settings.
+:::


### PR DESCRIPTION
### Changes

- Change Ash CLI installation instructions to adapt to Ash CLI being archived in a tar.gz
