### PR TITLE
feat: add Console local network guide

### DIFF
--- a/docs/console/guides/fuji-node/avalanche-node.md
+++ b/docs/console/guides/fuji-node/avalanche-node.md
@@ -10,7 +10,7 @@ The Ash Console is currently in alpha and **not production-ready**. It is under 
 
 We can finally deploy our Avalanche node [resource](/docs/console/glossary#resource)!
 
-1. Gather the node ID secret ID and cloud credentials secret ID from the previous steps.
+1. Gather the node ID secret ID and cloud region ID from the previous steps.
 2. Create the `avalancheNode` resource with the `console resource create` command:
 
    ```bash title="Command"

--- a/docs/console/guides/local-network/avalanche-nodes.md
+++ b/docs/console/guides/local-network/avalanche-nodes.md
@@ -1,0 +1,143 @@
+---
+sidebar_position: 6
+---
+
+# 4. Avalanche Nodes Deployment
+
+:::caution
+The Ash Console is currently in alpha and **not production-ready**. It is under active development and subject to breaking changes.
+:::
+
+We can finally deploy our 5 Avalanche node [resources](/docs/console/glossary#resource)!
+
+## Bootstrap node creation
+
+1. Gather the cloud region secret ID from the previous steps.
+2. Create the `avalancheNode` "avalanche-node-01" resource with the `console resource create` command:
+
+   ```bash title="Command"
+   ash console resource create "{
+     \"name\": \"avalanche-node-01\",
+     \"resourceType\": \"avalancheNode\",
+     \"cloudRegionId\": \"08183731-869f-4099-8725-9fe3b56cf0bf\",
+     \"nodeIdSecretId\": \"$secret_id_01\",
+     \"size\": \"medium\",
+     \"nodeConfig\": {
+       \"isBootstrapNode\": true,
+       \"avalancheNodeConfig\": {
+         \"avalanchego_version\":\"1.10.12\"
+       }
+     }
+   }"
+   ```
+
+   ```bash title="Output"
+   Resource successfully created in project '70228a47-5ab1-493b-b921-5c22b83bfbf7'!
+   +--------------------------------------+-------------------+---------------+--------------------------------------+--------+------------------+---------+--------------------------+
+   | Resource ID                          | Name              | Type          | Cloud region ID                      | Size   | Created at       | Status  | Resource specific        |
+   +======================================+===================+===============+======================================+========+==================+=========+==========================+
+   | 4e1d6b8c-fbb0-497b-94d9-a0c0e58a27fa | avalanche-node-01 | AvalancheNode | 08183731-869f-4099-8725-9fe3b56cf0bf | Medium | 2023-11-23T15:28 | Pending |  IP address   | pending  |
+   |                                      |                   |               |                                      |        |                  |         |  Running      | false    |
+   |                                      |                   |               |                                      |        |                  |         |  Bootstrapped | [false]  |
+   |                                      |                   |               |                                      |        |                  |         |  Healthy      | [false]  |
+   |                                      |                   |               |                                      |        |                  |         |  Restart req. | false    |
+   +--------------------------------------+-------------------+---------------+--------------------------------------+--------+------------------+---------+--------------------------+
+   ```
+
+   **Note:** See [Resource sizes](/docs/console/reference/resource-management#resource-sizes) for available resource sizes.
+
+:::tip
+`avalanche-node-01` is the "bootstrap" node. It has a different configuration than the other nodes of the local Avalanche network. See the [Create a resource](/docs/console/reference/resource-management#create-a-resource) for more information.
+:::
+
+
+## Other nodes creation
+
+1. Gather the `avalanche-node-01` resource ID from the previous step.
+
+   ```bash title="Command"
+   bootstrap_node_resource_id=$(ash console resource list --json | jq -r '.[].id')
+   ```
+
+2. Create the `avalancheNode` "avalanche-node-01" resource with the `console resource create` command:
+
+   ```bash title="Command"
+   for i in {2..5}; do
+    secret_id_var=secret_id_0$i
+    ash console resource create "{
+      \"name\": \"avalanche-node-0$i\",
+      \"resourceType\": \"avalancheNode\",
+      \"cloudRegionId\": \"08183731-869f-4099-8725-9fe3b56cf0bf\",
+      \"nodeIdSecretId\": \"$(eval "echo \$${secret_id_var}")\",
+      \"size\": \"medium\",
+      \"nodeConfig\": {
+        \"isBootstrapNode\": false,
+        \"avalancheNodeConfig\": {
+          \"avalanchego_version\":\"1.10.12\"
+        }
+      },
+      \"nodeBootstrapResourceId\": \"$bootstrap_node_resource_id\"
+    }"
+   done
+   ```
+
+:::caution
+- The above command takes about ~30 seconds to complete.
+- Providing a `nodeBootstrapResourceId` is only supported for resources created in the **same cloud region** as the bootstrap node.
+:::
+
+## Health
+
+1. It will take a few minutes before the local network is `Bootstrapped` and `Healthy`. You can get its updated status with the `console resource info` command:
+
+   ```bash title="Command"
+    ash console resource info 4e1d6b8c-fbb0-497b-94d9-a0c0e58a27fa
+   ```
+
+   ```bash title="Output"
+   +--------------------------------------+-------------------+---------------+--------------------------------------+--------+------------------+---------+-------------------------------------+
+   | Resource ID                          | Name              | Type          | Cloud region ID                      | Size   | Created at       | Status  | Resource specific                   |
+   +======================================+===================+===============+======================================+========+==================+=========+=====================================+
+   | 4e1d6b8c-fbb0-497b-94d9-a0c0e58a27fa | avalanche-node-01 | AvalancheNode | 08183731-869f-4099-8725-9fe3b56cf0bf | Medium | 2023-11-23T15:28 | Running |  IP address   | 3.210.183.166       |
+   |                                      |                   |               |                                      |        |                  |         |  Running      | true                |
+   |                                      |                   |               |                                      |        |                  |         |  Bootstrapped | [true, true, true]  |
+   |                                      |                   |               |                                      |        |                  |         |  Healthy      | [true]              |
+   |                                      |                   |               |                                      |        |                  |         |  Restart req. | false               |
+   +--------------------------------------+-------------------+---------------+--------------------------------------+--------+------------------+---------+-------------------------------------+
+   ```
+
+2. You can also query the node `info` endpoint with the `avalanche node info` command:
+
+   ```bash title="Command"
+   ash avalanche node info -n 3.210.183.166
+   ```
+
+   ```bash title="Output"
+    Node '3.210.183.166:9650':
+      ID:            NodeID-7Xhw2mDxuDS44j42TCB6U5579esbSt3Lg
+      Network:       local
+      Public IP:     172.31.9.135
+      Staking port:  9651
+      Versions:
+        AvalancheGo:  avalanche/1.10.12
+        Database:     v1.4.5
+        RPC Protocol: 28
+        Git commit:   145dfb0dc179d688f45ad44067ef6f9821148b36
+        VMs:
+          AvalancheVM: v1.10.12
+          Coreth:      v0.12.5
+          PlatformVM:  v1.10.12
+          Subnet VMs:  []
+      Uptime:
+        Rewarding stake:  100%
+        Weighted average: 100%
+   ```
+
+   **Note:** Your node IP address will be different.
+
+
+Your local Avalanche network is now up and running!
+
+:::note
+See the [reference](/docs/console/reference/resource-management) for more information about resources lifecycle management.
+:::

--- a/docs/console/guides/local-network/cloud-credentials.md
+++ b/docs/console/guides/local-network/cloud-credentials.md
@@ -1,0 +1,17 @@
+---
+sidebar_position: 3
+---
+
+# 1. Cloud Credentials Setup
+
+:::caution
+The Ash Console is currently in alpha and **not production-ready**. It is under active development and subject to breaking changes.
+:::
+
+To **deploy the Avalanche node [resource](/docs/console/glossary#resource) into your cloud account/subscription/project**, you need to provide the Console with appropriate credentials.
+
+1. Follow the instructions provided in the [Cloud Credentials reference](/docs/console/reference/cloud-credentials) to create a **cloud credentials [secret](/docs/console/glossary#secret)** in the Console.
+2. **Save the secret ID** for later use. You can always get it with the `console secret list` command:
+   ```bash
+   ash console secret list
+   ```

--- a/docs/console/guides/local-network/index.md
+++ b/docs/console/guides/local-network/index.md
@@ -1,0 +1,17 @@
+---
+sidebar_position: 2
+---
+
+# Avalanche Devnet (Local Network)
+
+:::caution
+The Ash Console is currently in alpha and **not production-ready**. It is under active development and subject to breaking changes.
+:::
+
+This guide will walk you through setting up a 5-node Avalanche devnet ([local network](https://docs.avax.network/nodes/configure/avalanchego-config-flags#network-id) network) with the Ash Console.
+
+Devnets allow you to develop your Subnet out of sight in an environment where you have full control!
+
+:::info
+Devnets use the `local` network setup with hardcoded validator nodes and airdrop address.
+:::

--- a/docs/console/guides/local-network/index.md
+++ b/docs/console/guides/local-network/index.md
@@ -8,7 +8,7 @@ sidebar_position: 2
 The Ash Console is currently in alpha and **not production-ready**. It is under active development and subject to breaking changes.
 :::
 
-This guide will walk you through setting up a 5-node Avalanche devnet ([local network](https://docs.avax.network/nodes/configure/avalanchego-config-flags#network-id) network) with the Ash Console.
+This guide will walk you through setting up a 5-node Avalanche devnet ([local network](https://docs.avax.network/nodes/configure/avalanchego-config-flags#network-id)) with the Ash Console.
 
 Devnets allow you to develop your Subnet out of sight in an environment where you have full control!
 

--- a/docs/console/guides/local-network/node-ids.md
+++ b/docs/console/guides/local-network/node-ids.md
@@ -1,0 +1,91 @@
+---
+sidebar_position: 4
+---
+
+# 2. Node ID Secrets Generation
+
+:::caution
+The Ash Console is currently in alpha and **not production-ready**. It is under active development and subject to breaking changes.
+:::
+
+The Ash Console **decorelates the node ID from Avalanche nodes**, so that you can have a better control over your validator nodes' lifecycle.
+
+Node IDs are stored as [secrets](/docs/console/glossary#secret) in the Console.
+
+In this part of the guide, we will create **5 node ID secrets** for the 5 nodes of our Avalanche devnet.
+
+:::tip
+The Node ID secrets need to match the hardcoded Node IDs in the [`genesis_local.json`](https://github.com/ava-labs/avalanchego/blob/master/genesis/genesis_local.json#L47) file of the [AvalancheGo](https://github.com/ava-labs/avalanchego) codebase.
+:::
+
+## Fetch the 5 node IDs certificates
+
+The [Local Test Network Creation tutorial](/docs/toolkit/ansible-avalanche-collection/tutorials/local-test-network) uses the same certificates and keys for the 5 validator nodes. Let's fetch the certificate and key files from the [`ansible-avalanche-getting-started`](https://github.com/AshAvalanche/ansible-avalanche-getting-started) repository.
+
+1. If not already done, create a folder for this guide and navigate to it:
+
+   ```bash
+   mkdir -p ash-console-guides/devnet-network
+   cd ash-console-guides/devnet-network
+   ```
+
+2. Fetch the local nodes certificates and keys from the [`ansible-avalanche-getting-started`](https://github.com/AshAvalanche/ansible-avalanche-getting-started/tree/main/files/staking) repository:
+
+   ```bash title="Command"
+   for i in {1..5}; do
+     curl -sSL https://raw.githubusercontent.com/AshAvalanche/ansible-avalanche-getting-started/main/files/staking/validator0$i.crt -o node0$i.crt
+     curl -sSL https://raw.githubusercontent.com/AshAvalanche/ansible-avalanche-getting-started/main/files/staking/validator0$i.key -o node0$i.key
+   done
+   ```
+
+## Create the node ID secrets
+
+Use the certificate and key files to create a `nodeId` secret for each cert/key pair with the `console secret create` command:
+
+```bash title="Command"
+# Node IDs
+nodeIds=("NodeID-7Xhw2mDxuDS44j42TCB6U5579esbSt3Lg" "NodeID-MFrZFVCXPv5iCn6M9K6XduxGTYp891xXZ" "NodeID-NFBbbJ4qCmNaCzeW7sxErhvWqvEQMnYcN" "NodeID-GWPcbFJZFfZreETSoWjPimr846mXEKCtu" "NodeID-P7oB2McjBGgW2NXXWVYjV8JEDFoW9xDE5")
+
+for i in {1..5}; do
+   secret_id_var=secret_id_0$i
+   eval $secret_id_var=$(ash console secret create "{
+      \"name\": \"node-id-0$i\",
+      \"secretType\": \"nodeId\",
+      \"nodeId\": \"${nodeIds[@]:$(($i - 1)):1}\",
+      \"nodeCert\": \"node0$i.crt\",
+      \"nodeKey\": \"node0$i.key\"
+   }" --json | jq .id)
+done
+```
+
+:::tip
+The Node ID secrets' IDs have been saved in environment variables (e.g.: `$secret_id_01`), we will use them later in this guide!
+:::
+
+We can then confirm that the secrets have been created with the `console secret list` command:
+
+```bash title="Command"
+ash console secret list
+```
+
+```bash title="Output"
++--------------------------------------+-------------+--------------------+----------------+------------------+---------+
+| Secret ID                            | Owner ID    | Name               | Type           | Created at       | Used by |
++======================================+=============+====================+================+==================+=========+
+| 43a4743f-1f29-4815-9dc3-b12dfd7bfb55 | fce8...3695 | node-id-01         | NodeId         | 2023-11-23T14:54 | 0       |
++--------------------------------------+-------------+--------------------+----------------+------------------+---------+
+| 7af586eb-627f-4fcb-8fc5-ab5fd7b6d0a1 | fce8...3695 | node-id-02         | NodeId         | 2023-11-23T14:54 | 0       |
++--------------------------------------+-------------+--------------------+----------------+------------------+---------+
+| f951bd5b-c005-4d75-b710-7ade6b0c7f41 | fce8...3695 | node-id-03         | NodeId         | 2023-11-23T14:54 | 0       |
++--------------------------------------+-------------+--------------------+----------------+------------------+---------+
+| a3748643-e94f-4cd1-be47-22ec6177dfb8 | fce8...3695 | node-id-04         | NodeId         | 2023-11-23T14:54 | 0       |
++--------------------------------------+-------------+--------------------+----------------+------------------+---------+
+| ec23306c-0003-427d-9d78-b12a2f797e36 | fce8...3695 | node-id-05         | NodeId         | 2023-11-23T14:54 | 0       |
++--------------------------------------+-------------+--------------------+----------------+------------------+---------+
+```
+
+**Note:** Your secret IDs will be different.
+
+:::note
+See the [reference](/docs/console/reference/secret-management) for more information about secrets lifecycle management.
+:::

--- a/docs/console/guides/local-network/prerequisites.md
+++ b/docs/console/guides/local-network/prerequisites.md
@@ -1,0 +1,28 @@
+---
+sidebar_position: 2
+---
+
+# 0. Prerequisites
+
+:::caution
+The Ash Console is currently in alpha and **not production-ready**. It is under active development and subject to breaking changes.
+:::
+
+:::info
+During the Console alpha, **user accounts are created by the Ash team**. If you want to get access to the Console alpha, please contact us!
+
+- [Register in advance](https://forms.gle/m66KkKT8FC2Jb9Y97)
+- [Book a call](https://calendly.com/ash-e36knots)
+- [DM us on Twitter](https://twitter.com/ash_avax)
+- [Join our Discord](https://discord.gg/7xSEzC2n7v)
+
+:::
+
+To follow this guide, you will need:
+
+- The **[Ash CLI](/docs/toolkit/ash-cli/introduction) installed** in a version >= `0.4.0-alpha.X`. See [Ash CLI - Installation](/docs/toolkit/ash-cli/installation).
+- A **user account** in the Ash Console and an open session in the CLI. See [Authentication](/docs/console/reference/authentication).
+- An account in one of the following cloud providers:
+  - [AWS](https://aws.amazon.com/)
+  - [Azure](https://azure.microsoft.com/) (account = subscription)
+  - [Google Cloud](https://cloud.google.com/) (account = project)

--- a/docs/console/guides/local-network/project-region.md
+++ b/docs/console/guides/local-network/project-region.md
@@ -1,0 +1,59 @@
+---
+sidebar_position: 5
+---
+
+# 3. Project and Cloud Region Creation
+
+:::caution
+The Ash Console is currently in alpha and **not production-ready**. It is under active development and subject to breaking changes.
+:::
+
+The Avalanche node [resources](/docs/console/glossary#resource) will be deployed into a [cloud region](/docs/console/glossary#cloud-region) of a [project](/docs/console/glossary#project).
+
+## Create a project
+
+Create a project on the `local` network for this guide with the `console project create` command:
+
+```bash title="Command"
+ash console project create '{"name": "devnet-guide", "network": "local"}'
+```
+
+```bash title="Output"
+Project created successfully!
++--------------------------------------+-------------+---------------------+---------+---------------+------------------+
+| Project ID                           | Owner ID    | Name                | Network | Cloud regions | Created at       |
++======================================+=============+=====================+=========+===============+==================+
+| 70228a47-5ab1-493b-b921-5c22b83bfbf7 | fce8...3695 | devnet-guide        | Local   |               | 2023-11-23T15:08 |
++--------------------------------------+-------------+---------------------+---------+---------------+------------------+
+
+Switched to project 'local-network-guide' (70228a47-5ab1-493b-b921-5c22b83bfbf7)!
+```
+
+:::note
+See the [reference](/docs/console/reference/project-management) for more information about projects lifecycle management.
+:::
+
+**Note:** Your project ID will be different.
+
+## Add a cloud region to the project
+
+Add a cloud region of your choice to the project with the `console region add` ([list of supported regions](/docs/console/glossary#cloud-region))
+
+**Note:** You need the **ID of the cloud credentials secret** created in [step 1.](/docs/console/guides/local-network/cloud-credentials)
+
+```bash title="Command"
+ash console region add '{"cloudProvider": "aws", "region": "us-east-1", "cloudCredentialsSecretId": "69ba9d5e-9454-449f-848c-de14005e68d4"}'
+```
+
+```bash title="Output"
+Cloud region successfully added to project '70228a47-5ab1-493b-b921-5c22b83bfbf7'!
++--------------------------------------+----------------+--------------+-----------------------+------------------+-----------+
+| Region ID                            | Cloud provider | Cloud region | Cloud creds secret ID | Created at       | Status    |
++======================================+================+==============+=======================+==================+===========+
+| 08183731-869f-4099-8725-9fe3b56cf0bf | aws            | us-east-1    | 69ba...68d4           | 2023-11-23T15:12 | Available |
++--------------------------------------+----------------+--------------+-----------------------+------------------+-----------+
+```
+
+:::note
+See the [reference](/docs/console/reference/resource-management) for more information about cloud regions lifecycle management.
+:::


### PR DESCRIPTION
### Linked issues

- Fix #69 

### Changes

- Add Avalanche Local network guide

### Additional comments

- Prerequisites, Cloud credential setup and project setup are duplicated from the Avalanche Fuji node guide
