### PR TITLE
[WIP] fix: set subnet evm at 0.6.3

### DIFF
--- a/docs/toolkit/ansible-avalanche-collection/changelog.md
+++ b/docs/toolkit/ansible-avalanche-collection/changelog.md
@@ -1,8 +1,52 @@
 # Changelog
 
-## [Unreleased](https://github.com/AshAvalanche/ansible-avalanche-collection/tree/HEAD)
+## [v0.13.0](https://github.com/AshAvalanche/ansible-avalanche-collection/tree/v0.13.0) (2024-04-24)
 
-[Full Changelog](https://github.com/AshAvalanche/ansible-avalanche-collection/compare/v0.12.3...HEAD)
+[Full Changelog](https://github.com/AshAvalanche/ansible-avalanche-collection/compare/v0.12.7...v0.13.0)
+
+**Merged pull requests:**
+
+- feat: upgrade avalanchego version [\#132](https://github.com/AshAvalanche/ansible-avalanche-collection/pull/132) ([Al3xGROS](https://github.com/Al3xGROS))
+
+## [v0.12.7](https://github.com/AshAvalanche/ansible-avalanche-collection/tree/v0.12.7) (2024-04-10)
+
+[Full Changelog](https://github.com/AshAvalanche/ansible-avalanche-collection/compare/v0.12.6...v0.12.7)
+
+**Merged pull requests:**
+
+- fix\(blockscout\): add tags on playbook [\#131](https://github.com/AshAvalanche/ansible-avalanche-collection/pull/131) ([servalD](https://github.com/servalD))
+
+## [v0.12.6](https://github.com/AshAvalanche/ansible-avalanche-collection/tree/v0.12.6) (2024-03-29)
+
+[Full Changelog](https://github.com/AshAvalanche/ansible-avalanche-collection/compare/v0.12.5...v0.12.6)
+
+**Implemented enhancements:**
+
+- Upgrade Blockscout to 6.x [\#119](https://github.com/AshAvalanche/ansible-avalanche-collection/issues/119)
+
+**Merged pull requests:**
+
+- fix\(blockscout\): Add smart contract verifier [\#130](https://github.com/AshAvalanche/ansible-avalanche-collection/pull/130) ([servalD](https://github.com/servalD))
+
+## [v0.12.5](https://github.com/AshAvalanche/ansible-avalanche-collection/tree/v0.12.5) (2024-03-12)
+
+[Full Changelog](https://github.com/AshAvalanche/ansible-avalanche-collection/compare/v0.12.4...v0.12.5)
+
+**Implemented enhancements:**
+
+- Dynamically check for VM version compatibility [\#128](https://github.com/AshAvalanche/ansible-avalanche-collection/issues/128)
+
+**Closed issues:**
+
+- Remove `snow-sample-size` [\#127](https://github.com/AshAvalanche/ansible-avalanche-collection/issues/127)
+
+**Merged pull requests:**
+
+- feat: add + use vm\_version\_compat module [\#129](https://github.com/AshAvalanche/ansible-avalanche-collection/pull/129) ([Nuttymoon](https://github.com/Nuttymoon))
+
+## [v0.12.4](https://github.com/AshAvalanche/ansible-avalanche-collection/tree/v0.12.4) (2024-03-01)
+
+[Full Changelog](https://github.com/AshAvalanche/ansible-avalanche-collection/compare/v0.12.3...v0.12.4)
 
 **Merged pull requests:**
 

--- a/docs/toolkit/ansible-avalanche-collection/tutorials/vm-management.md
+++ b/docs/toolkit/ansible-avalanche-collection/tutorials/vm-management.md
@@ -22,11 +22,11 @@ For now only the [Subnet EVM](https://github.com/ava-labs/subnet-evm) is support
 
 The VMs are managed by the `avalanchego_vms_install` role variable which is empty by default ([`avalanchego_vms_install: {}`](https://github.com/AshAvalanche/ansible-avalanche-collection/blob/main/roles/node/defaults/main.yml#L42)).
 
-To add a new VM that will be installed on our validator nodes, we just have to update the `avalanchego_vms_install` variable. For the next example, we will install Ava Labs' [Subnet EVM](https://github.com/ava-labs/subnet-evm) in version `0.5.5`. The variable we are should be added to [`avalanche_nodes.yml`](https://github.com/AshAvalanche/ansible-avalanche-getting-started/tree/main/inventories/local/group_vars/avalanche_nodes.yml):
+To add a new VM that will be installed on our validator nodes, we just have to update the `avalanchego_vms_install` variable. For the next example, we will install Ava Labs' [Subnet EVM](https://github.com/ava-labs/subnet-evm) in version `0.6.3`. The variable we are should be added to [`avalanche_nodes.yml`](https://github.com/AshAvalanche/ansible-avalanche-getting-started/tree/main/inventories/local/group_vars/avalanche_nodes.yml):
 
 ```yml title="inventories/local/group_vars/avalanche_nodes.yml"
 avalanchego_vms_install:
-  subnet-evm: 0.5.5
+  subnet-evm: 0.6.3
 ```
 
 We can then install this VM to all the nodes defined in our Ansible inventory by running the `provision_nodes` playbook again:


### PR DESCRIPTION
### Changes

- in `Blockchain VM Management` tab, set `subnet-evm` to 0.6.3 for compatibility purposes with AvalancheGo 1.11.3

### Additional comments

To be updated with newer versions...
