### PR TITLE
fix: update link state sync

### DIFF
--- a/docs/console/guides/fuji-node/avalanche-node.md
+++ b/docs/console/guides/fuji-node/avalanche-node.md
@@ -45,7 +45,7 @@ The Ash Console subcommands support both JSON and YAML.
    +-------------------+-------------+---------------+-----------------+--------+------------------+---------+--------------------------+
    ```
 
-   **Note:** By default, [state sync](https://docs.avax.network/nodes/configure/chain-config-flags#state-sync) is enabled on the C-Chain.
+   **Note:** By default, [state sync](https://docs.avax.network/nodes/configure/chain-configs/C#state-sync) is enabled on the C-Chain.
 
    **Note:** See [Resource sizes](/docs/console/reference/resource-management#resource-sizes) for available resource sizes.
 


### PR DESCRIPTION


### Changes


- Link to avax documentation was broken. Added new link towards [avax node doc](https://docs.avax.network/nodes/configure/chain-configs/C#state-sync

