### PR TITLE
fix(console): add subnet-evm version to install it in devnet node dep…

### DIFF
--- a/docs/console/guides/local-network/avalanche-nodes.md
+++ b/docs/console/guides/local-network/avalanche-nodes.md
@@ -20,7 +20,10 @@ We will use the `sharedResourceConfig` field of the project to set this shared c
 ash console project update devnet-guide '{
   sharedResourceConfig: {
     avalancheNodeConfig: {
-      avalanchego_version: 1.10.17
+      avalanchego_version: 1.10.17,
+      avalanchego_vms_install: {
+        subnet-evm: 0.5.10
+      }
     }
   }
 }'


### PR DESCRIPTION
### Changes

- Add subnet evm version on the avalanche devnet node deployment guide to fix its installation
