### PR TITLE
feat: update versions vm and avalanchego

### DIFF
--- a/docs/toolkit/ansible-avalanche-collection/changelog.md
+++ b/docs/toolkit/ansible-avalanche-collection/changelog.md
@@ -1,8 +1,52 @@
 # Changelog
 
-## [Unreleased](https://github.com/AshAvalanche/ansible-avalanche-collection/tree/HEAD)
+## [v0.13.0](https://github.com/AshAvalanche/ansible-avalanche-collection/tree/v0.13.0) (2024-04-24)
 
-[Full Changelog](https://github.com/AshAvalanche/ansible-avalanche-collection/compare/v0.12.3...HEAD)
+[Full Changelog](https://github.com/AshAvalanche/ansible-avalanche-collection/compare/v0.12.7...v0.13.0)
+
+**Merged pull requests:**
+
+- feat: upgrade avalanchego version [\#132](https://github.com/AshAvalanche/ansible-avalanche-collection/pull/132) ([Al3xGROS](https://github.com/Al3xGROS))
+
+## [v0.12.7](https://github.com/AshAvalanche/ansible-avalanche-collection/tree/v0.12.7) (2024-04-10)
+
+[Full Changelog](https://github.com/AshAvalanche/ansible-avalanche-collection/compare/v0.12.6...v0.12.7)
+
+**Merged pull requests:**
+
+- fix\(blockscout\): add tags on playbook [\#131](https://github.com/AshAvalanche/ansible-avalanche-collection/pull/131) ([servalD](https://github.com/servalD))
+
+## [v0.12.6](https://github.com/AshAvalanche/ansible-avalanche-collection/tree/v0.12.6) (2024-03-29)
+
+[Full Changelog](https://github.com/AshAvalanche/ansible-avalanche-collection/compare/v0.12.5...v0.12.6)
+
+**Implemented enhancements:**
+
+- Upgrade Blockscout to 6.x [\#119](https://github.com/AshAvalanche/ansible-avalanche-collection/issues/119)
+
+**Merged pull requests:**
+
+- fix\(blockscout\): Add smart contract verifier [\#130](https://github.com/AshAvalanche/ansible-avalanche-collection/pull/130) ([servalD](https://github.com/servalD))
+
+## [v0.12.5](https://github.com/AshAvalanche/ansible-avalanche-collection/tree/v0.12.5) (2024-03-12)
+
+[Full Changelog](https://github.com/AshAvalanche/ansible-avalanche-collection/compare/v0.12.4...v0.12.5)
+
+**Implemented enhancements:**
+
+- Dynamically check for VM version compatibility [\#128](https://github.com/AshAvalanche/ansible-avalanche-collection/issues/128)
+
+**Closed issues:**
+
+- Remove `snow-sample-size` [\#127](https://github.com/AshAvalanche/ansible-avalanche-collection/issues/127)
+
+**Merged pull requests:**
+
+- feat: add + use vm\_version\_compat module [\#129](https://github.com/AshAvalanche/ansible-avalanche-collection/pull/129) ([Nuttymoon](https://github.com/Nuttymoon))
+
+## [v0.12.4](https://github.com/AshAvalanche/ansible-avalanche-collection/tree/v0.12.4) (2024-03-01)
+
+[Full Changelog](https://github.com/AshAvalanche/ansible-avalanche-collection/compare/v0.12.3...v0.12.4)
 
 **Merged pull requests:**
 

--- a/docs/toolkit/ansible-avalanche-collection/reference/roles/avalanche-node.md
+++ b/docs/toolkit/ansible-avalanche-collection/reference/roles/avalanche-node.md
@@ -120,6 +120,10 @@ Here is the compatibility matrix with AvalancheGo versions:
 | `28`         | `1.10.9-1.10.12`  | `0.5.5-0.5.6`   |
 | `29`         | `1.10.13-1.10.14` | `0.5.7-0.5.8`   |
 | `30`         | `1.10.15-1.10.17` | `0.5.9-0.5.10`  |
+| `31`         | `1.10.18-1.10.19` | `0.5.11`        |
+| `33`         | `1.11.0-1.11.1`   | `0.6.0-0.6.1`   |
+| `34`         | `1.11.2`          | `0.6.2`         |
+| `35`         | `1.11.3-1.11.7`   | `0.6.3-0.6.6`   |
 
 :::tip
 If a versions incompatibility is detected, an error message will be prompted and the role execution will stop.

--- a/docs/toolkit/ansible-avalanche-collection/tutorials/node-upgrade.md
+++ b/docs/toolkit/ansible-avalanche-collection/tutorials/node-upgrade.md
@@ -35,7 +35,7 @@ Node '127.0.0.1:9650':
   Public IP:     10.117.207.160
   Staking port:  9651
   Versions:
-    AvalancheGo:  avalanche/1.10.9
+    AvalancheGo:  avalanche/1.11.3
     [...]
 ```
 
@@ -54,20 +54,20 @@ jq -r '.result.version'
 ```
 
 ```bash title="Output"
-avalanche/1.10.9
+avalanche/1.11.3
 ```
 
   </TabItem>
 </Tabs>
 
-As we can see above, our node is currently running AvalancheGo version `1.10.9`. This is what's expected because of the Ansible role variable `avalanchego_version: 1.10.9` set at [avalanche_nodes.yml](https://github.com/AshAvalanche/ansible-avalanche-getting-started/blob/main/inventories/local/group_vars/avalanche_nodes.yml#L4) in our inventory.
+As we can see above, our node is currently running AvalancheGo version `1.11.3`. This is what's expected because of the Ansible role variable `avalanchego_version: 1.11.3` set at [avalanche_nodes.yml](https://github.com/AshAvalanche/ansible-avalanche-getting-started/blob/main/inventories/local/group_vars/avalanche_nodes.yml#L4) in our inventory.
 
 ## Upgrade the AvalancheGo version
 
-Let's upgrade our nodes by changing the `avalanchego_version` Ansible variable to `1.10.10` with the following command:
+Let's upgrade our nodes by changing the `avalanchego_version` Ansible variable to `1.11.4` with the following command:
 
 ```bash
-sed -i 's/avalanchego_version: 1.10.9/avalanchego_version: 1.10.10/' inventories/local/group_vars/avalanche_nodes.yml
+sed -i 's/avalanchego_version: 1.11.3/avalanchego_version: 1.11.4/' inventories/local/group_vars/avalanche_nodes.yml
 ```
 
 We can then upgrade all the nodes defined in our Ansible inventory by running the `provision_nodes` playbook again:
@@ -87,7 +87,7 @@ By running the same command as previously:
 multipass exec validator01 -- ash avalanche node info
 ```
 
-We can confirm that our node is now running AvalancheGo `1.10.10`:
+We can confirm that our node is now running AvalancheGo `1.11.4`:
 
 ```bash {7}
 Node '127.0.0.1:9650':
@@ -96,7 +96,7 @@ Node '127.0.0.1:9650':
   Public IP:     10.117.207.160
   Staking port:  9651
   Versions:
-    AvalancheGo:  avalanche/1.10.10
+    AvalancheGo:  avalanche/1.11.4
     [...]
 ```
 
@@ -114,10 +114,10 @@ multipass exec validator01 -- curl -s -X POST --data '{
 jq -r '.result.version'
 ```
 
-We can confirm that our node is now running AvalancheGo `1.10.10`:
+We can confirm that our node is now running AvalancheGo `1.11.4`:
 
 ```bash
-avalanche/1.10.10
+avalanche/1.11.4
 ```
 
   </TabItem>

--- a/docs/toolkit/ansible-avalanche-collection/tutorials/vm-management.md
+++ b/docs/toolkit/ansible-avalanche-collection/tutorials/vm-management.md
@@ -22,11 +22,11 @@ For now only the [Subnet EVM](https://github.com/ava-labs/subnet-evm) is support
 
 The VMs are managed by the `avalanchego_vms_install` role variable which is empty by default ([`avalanchego_vms_install: {}`](https://github.com/AshAvalanche/ansible-avalanche-collection/blob/main/roles/node/defaults/main.yml#L42)).
 
-To add a new VM that will be installed on our validator nodes, we just have to update the `avalanchego_vms_install` variable. For the next example, we will install Ava Labs' [Subnet EVM](https://github.com/ava-labs/subnet-evm) in version `0.5.5`. The variable we are should be added to [`avalanche_nodes.yml`](https://github.com/AshAvalanche/ansible-avalanche-getting-started/tree/main/inventories/local/group_vars/avalanche_nodes.yml):
+To add a new VM that will be installed on our validator nodes, we just have to update the `avalanchego_vms_install` variable. For the next example, we will install Ava Labs' [Subnet EVM](https://github.com/ava-labs/subnet-evm) in version `0.6.3`. The variable we are should be added to [`avalanche_nodes.yml`](https://github.com/AshAvalanche/ansible-avalanche-getting-started/tree/main/inventories/local/group_vars/avalanche_nodes.yml):
 
 ```yml title="inventories/local/group_vars/avalanche_nodes.yml"
 avalanchego_vms_install:
-  subnet-evm: 0.5.5
+  subnet-evm: 0.6.3
 ```
 
 We can then install this VM to all the nodes defined in our Ansible inventory by running the `provision_nodes` playbook again:
@@ -52,7 +52,7 @@ ll /opt/avalanche/avalanchego/current/plugins/
 total 8
 drwxr-xr-x 2 avalanche avalanche 4096 Jul 25 11:21 ./
 drwxr-xr-x 3 avalanche avalanche 4096 Jul 25 11:05 ../
-lrwxrwxrwx 1 root      root        58 Jul 25 11:21 subnet-evm -> /opt/avalanche/vms/subnet-evm/subnet-evm-v0.5.5/subnet-evm*
+lrwxrwxrwx 1 root      root        58 Jul 25 11:21 subnet-evm -> /opt/avalanche/vms/subnet-evm/subnet-evm-v0.6.3/subnet-evm*
 ```
 
 AvalancheGo has been automatically restarted and the VM is ready to be used.
@@ -61,11 +61,11 @@ AvalancheGo has been automatically restarted and the VM is ready to be used.
 
 Upgrading a VM is as simple as updating the `avalanchego_vms_install` variable.
 
-For example, if we want to upgrade the `subnet-evm` from version `0.5.5` to `0.5.6`:
+For example, if we want to upgrade the `subnet-evm` from version `0.6.3` to `0.6.4`:
 
 ```yml title="inventories/local/group_vars/avalanche_nodes.yml"
 avalanchego_vms_install:
-  subnet-evm: 0.5.6
+  subnet-evm: 0.6.4
 ```
 
 Re-run the `provision_nodes` playbook:
@@ -86,7 +86,7 @@ ll /opt/avalanche/avalanchego/current/plugins/
 total 8
 drwxr-xr-x 2 avalanche avalanche 4096 Jul 25 11:22 ./
 drwxr-xr-x 3 avalanche avalanche 4096 Jul 25 11:05 ../
-lrwxrwxrwx 1 root      root        58 Jul 25 11:22 subnet-evm -> /opt/avalanche/vms/subnet-evm/subnet-evm-v0.5.6/subnet-evm*
+lrwxrwxrwx 1 root      root        58 Jul 25 11:22 subnet-evm -> /opt/avalanche/vms/subnet-evm/subnet-evm-v0.6.4/subnet-evm*
 ```
 
 ## Uninstall a VM
@@ -111,8 +111,8 @@ avalanchego_vms_list:
     binary_filename: m1
     versions_comp:
       0.1.0:
-        ge: 1.10.9
-        le: 1.10.12
+        ge: 1.11.3
+        le: 1.11.7
 ```
 
 Here are some details about the variables:
@@ -142,5 +142,5 @@ ansible-playbook ash.avalanche.provision_nodes -i inventories/local
 ```
 
 :::caution
-For security reasons, the collection will checksum test the downloaded VM. The checksum file must be available at the same location as the VM binary archive. The standard follows is the same as Ava Lab's [Subnet EVM](https://github.com/ava-labs/subnet-evm) (see release [v0.5.3](https://github.com/ava-labs/subnet-evm/releases/tag/v0.5.3) for an example.).
+For security reasons, the collection will checksum test the downloaded VM. The checksum file must be available at the same location as the VM binary archive. The standard follows is the same as Ava Lab's [Subnet EVM](https://github.com/ava-labs/subnet-evm) (see release [v0.6.3](https://github.com/ava-labs/subnet-evm/releases/tag/v0.6.3) for an example.).
 :::


### PR DESCRIPTION
### Linked issues

[AvalancheGo updated to 1.11.3](https://github.com/AshAvalanche/ansible-avalanche-getting-started/blob/main/inventories/local/group_vars/avalanche_nodes.yml#L4), so the documentation needed an update here and regarding the VM installed. 

### Additional comments

- Didn't realize the PR of @Al3xGROS was there before doing the changes. 
- Not sure if the version of m1 should change from 0.1.0 to the latest release in the forked repository. 
